### PR TITLE
CA-4731-resize-photos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-eng/react-avatar-editor",
-  "version": "3.133.1",
+  "version": "3.133.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-eng/react-avatar-editor",
-  "version": "3.133.1",
+  "version": "3.133.2",
   "description": "Avatar / profile picture component. Resize and crop your uploaded image using a intuitive user interface.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import get from 'lodash/get'
-import isEmpty from 'lodash/isEmpty'
 
 import loadImageURL from './utils/load-image-url'
 import loadImageFile from './utils/load-image-file'
@@ -645,17 +644,6 @@ class AvatarEditor extends React.Component {
       height,
       width,
     }
-  }
-
-  // rect dimensions used to draw the inner rect, and the bleed marks
-  getRect(bleed = {}, posX, posY, bleedDistance, canvasW, canvasH) {
-    const distance = !isEmpty(bleed) ? bleedDistance : 0
-    const top = posY
-    const left = posX
-    const bottom = canvasH - posY
-    const right = canvasW - posX
-
-    return [top, left, bottom, right]
   }
 
   paint(context) {

--- a/src/index.js
+++ b/src/index.js
@@ -149,36 +149,41 @@ const drawRoundedRect = (context, x, y, width, height, borderRadius) => {
  * @param {number} innerBoxWidth [width of rectangle that holds the image]
  * @param {number} innerBoxHeight [height of rectangle that holds the image]
 */
-const drawCutLines = (context, outerBoxX, outerBoxY, innerBoxWidth, innerBoxHeight) => {
+const drawCutLines = (context, outerBoxX, outerBoxY, innerBoxWidth, innerBoxHeight, bleedDistance, bleedEdges) => {
+  const bleedTop = bleedEdges.top ? bleedDistance : 0
+  const bleedRight = bleedEdges.right ? bleedDistance : 0
+  const bleedBottom = bleedEdges.bottom ? bleedDistance : 0
+  const bleedLeft = bleedEdges.left ? bleedDistance : 0
+
   context.strokeStyle = '#ffffff';
   context.lineWidth = 2;
   context.setLineDash([7, 3]);
 
   // top 
   context.beginPath();
-  context.moveTo(0, outerBoxY);
-  context.lineTo(innerBoxWidth, outerBoxY);
+  context.moveTo(0, outerBoxY + bleedTop);
+  context.lineTo(innerBoxWidth, outerBoxY + bleedTop);
   context.stroke();
   context.closePath();
 
   // right
   context.beginPath();
-  context.moveTo(innerBoxWidth - outerBoxX, 0);
-  context.lineTo(innerBoxWidth - outerBoxX, innerBoxHeight);
+  context.moveTo(innerBoxWidth - outerBoxX - bleedRight, 0);
+  context.lineTo(innerBoxWidth - outerBoxX - bleedRight, innerBoxHeight);
   context.stroke();
   context.closePath();
 
   // bottom
   context.beginPath();
-  context.moveTo(0, innerBoxHeight - outerBoxY);
-  context.lineTo(innerBoxWidth, innerBoxHeight - outerBoxY);
+  context.moveTo(0, innerBoxHeight - outerBoxY - bleedBottom);
+  context.lineTo(innerBoxWidth, innerBoxHeight - outerBoxY - bleedBottom);
   context.stroke();
   context.closePath();
 
   // left
   context.beginPath();
-  context.moveTo(outerBoxX, 0);
-  context.lineTo(outerBoxX, innerBoxHeight);
+  context.moveTo(outerBoxX + bleedLeft, 0);
+  context.lineTo(outerBoxX + bleedLeft, innerBoxHeight);
   context.stroke();
   context.closePath();
 }
@@ -645,17 +650,10 @@ class AvatarEditor extends React.Component {
   // rect dimensions used to draw the inner rect, and the bleed marks
   getRect(bleed = {}, posX, posY, bleedDistance, canvasW, canvasH) {
     const distance = !isEmpty(bleed) ? bleedDistance : 0
-
-    // create offsets for the right and bottom bleeds if there are no left and top bleeds
-    const offsetX = bleed.left ? 2 : 1
-    const offsetY = bleed.top ? 2 : 1
-
-    const top = bleed.top ? posY - distance : posY
-    const left = bleed.left ? posX - distance : posX
-    const bottom = bleed.bottom ? 
-      (canvasH - posY * 2) + (distance * offsetY) : (canvasH - posY * 2) + distance
-    const right = bleed.right ?
-      (canvasW - posX * 2) + (distance * offsetX) : (canvasW - posX * 2) + distance
+    const top = posY
+    const left = posX
+    const bottom = canvasH - posY
+    const right = canvasW - posX
 
     return [top, left, bottom, right]
   }
@@ -673,7 +671,6 @@ class AvatarEditor extends React.Component {
     const width = dimensions.canvas.width
     const bleedDistance = get(this.props, 'printMarks.bleedDistance', 0)
     const bleedEdges = get(this.props, 'printMarks.bleedEdges')
-    const [rectTop, rectLeft, rectBottom, rectRight] = this.getRect(bleedEdges, borderSizeX, borderSizeY, bleedDistance, width, height)
 
     // clamp border radius between zero (perfect rectangle) and half the size without borders (perfect circle or "pill")
     borderRadius = Math.max(borderRadius, 0)
@@ -687,10 +684,10 @@ class AvatarEditor extends React.Component {
     // inner rect, possibly rounded
     drawRoundedRect(
       context,
-      rectLeft,
-      rectTop,
-      rectRight,
-      rectBottom,
+      borderSizeX,
+      borderSizeY,
+      width - borderSizeX * 2,
+      height - borderSizeY * 2,
       borderRadius
     )
     context.rect(width, 0, -width, height) // outer rect, drawn "counterclockwise"
@@ -704,16 +701,18 @@ class AvatarEditor extends React.Component {
         borderSizeX,
         borderSizeY,
         width, 
-        height
+        height,
+        bleedDistance,
+        bleedEdges
       )
   
       // red border
       drawBleedRect(
         context, 
-        rectLeft,
-        rectTop,
-        rectRight,
-        rectBottom,
+        borderSizeX,
+        borderSizeY,
+        width - borderSizeX * 2,
+        height - borderSizeY * 2
       )
     }
 


### PR DESCRIPTION
### What's this PR do?
This PR refactors the work previously done for the bleeds epic. The first iteration kept the image dimensions at its original size and simply expanded the viewable area of the editor, and applied the bleed marks into this extra space. This turned out not to be correct because if the viewable area is expanded, the final rendered image is also expanded. 

Instead of expanding the viewable area of the editor, the code now places the bleed marks inside of the original dimensions of the image being edited. If bleed marks are toggled on in collateral-viewer, then an image will already be expanded there, and when it is opened in the editor, there should be no further expansion needed; only the bleed marks need to be applied. 

### What are the important parts of the code?

### How should this be tested by the reviewer?
This needs to be tested along with the PR for Collateral-Viewer: https://github.com/reside-eng/collateral-viewer/pull/240

<!-- Please be sure to write tests for both Brawndo and Cider when making changes to this codebase, and provide setup instructions for each role.  -->

**Test as Role:**

#### Set-up

#### Tests

<!-- Tests should have a checkbox for reviewers to mark as complete after they perform each test. -->

<!-- For example:
- [ ] **test 1** -->

#### Environments to test

<!-- Please delete the environments that are not relevant. -->

- Desktop - MacOS - Browser (Chrome)
- Desktop - Windows - Browser (Chrome)
- Mobile - iOS - App (GoNative)
- Mobile - iOS - Browser (Safari)
- Mobile - Android - App (GoNative)
- Mobile - Android - Browser (Chrome)
- Tablet - iOS - App (GoNative)
- Tablet - iOS - Browser (Safari)
- Tablet - Android - App (GoNative)
- Tablet - Android - Browser (Chrome)

#### Have you tested with a new transaction?

#### Thoughts about Backwards Compatibility?

#### Are there any edge cases you came across?

### Does any documentation need to be added or updated?

<!-- Make sure to update feature docs, and on-boarding docs (if the environment set-up has changed) -->

### Is any other information necessary to understand this?

### What are the relevant tickets? (Please add `closes`, `refs`, etc)

- closes [CA-4731](https://residenetwork.atlassian.net/browse/CA-4731)

#### Screenshots (if appropriate)
