### PR TITLE
CORE-104-cut-over-bleed-lines

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -683,6 +683,15 @@ class AvatarEditor extends React.Component {
 
     // draw the print marks if the bleed edges exist
     if (bleedEdges) {
+      // red border
+      drawBleedRect(
+        context, 
+        borderSizeX,
+        borderSizeY,
+        width - borderSizeX * 2,
+        height - borderSizeY * 2
+      )
+
       // white dotted line
       drawCutLines(
         context, 
@@ -692,15 +701,6 @@ class AvatarEditor extends React.Component {
         height,
         bleedDistance,
         bleedEdges
-      )
-  
-      // red border
-      drawBleedRect(
-        context, 
-        borderSizeX,
-        borderSizeY,
-        width - borderSizeX * 2,
-        height - borderSizeY * 2
       )
     }
 


### PR DESCRIPTION
In the current app, the bleed lines are over the cut lines. This task changes it around so that the cut lines are over the bleed lines. 

**To test in Int-c**
- In Cider, Create a template with a bleed: https://docs.google.com/document/d/1OEPrQ1oJgLVoz-WyYppkGQJkfvBY9lvEcV18cls_WNA/edit?pli=1#heading=h.lo410ey6n7up
- In Brawndo, hard refresh and create a new marketing request that contains your template.
![image](https://user-images.githubusercontent.com/806601/73186833-6ccd2800-40ee-11ea-8ecc-87adeb538b45.png)
- Add your image, and then edit the image
![image](https://user-images.githubusercontent.com/806601/73186884-7ce50780-40ee-11ea-8d6d-32995aba4ab2.png)
- [ ] You should now see that the cut lines (dashed white lines) are over the bleed lines (pink lines)